### PR TITLE
docs: improve diagram color scheme and add custom stylesheet

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -35,13 +35,13 @@ flowchart LR
     SERVERS --> BIGIP
     BIGIP -.->|"return traffic<br/>via ISP uplink<br/>(asymmetric path)"| INET
 
-    style DROP fill:#c62828,color:#fff
-    style INET fill:#616161,color:#fff
-    style SCRUB fill:#2e7d32,color:#fff
-    style BIGIP fill:#1565c0,color:#fff
-    style SERVERS fill:#1565c0,color:#fff
-    style DC fill:#e3f2fd,stroke:#1565c0,color:#000
-    style XC fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style DROP fill:#8E2424,color:#fff,stroke:#C62828
+    style INET fill:#455A64,color:#fff,stroke:#78909C
+    style SCRUB fill:#00838F,color:#fff,stroke:#00ACC1
+    style BIGIP fill:#1565C0,color:#fff,stroke:#42A5F5
+    style SERVERS fill:#37474F,color:#fff,stroke:#78909C
+    style DC fill:#263238,stroke:#78909C,color:#fff
+    style XC fill:#1A2744,stroke:#2196F3,color:#fff
 ```
 
 ### Prerequisites
@@ -137,14 +137,14 @@ flowchart LR
     BIGIPA --> NET
     BIGIPB --> NET
 
-    style INET fill:#616161,color:#fff
-    style SJC fill:#4a90d9,color:#fff
-    style IAD fill:#4a90d9,color:#fff
-    style BIGIPA fill:#2e7d32,color:#fff
-    style BIGIPB fill:#f57f17,color:#fff
-    style NET fill:#1565c0,color:#fff
-    style DC fill:#e3f2fd,stroke:#1565c0,color:#000
-    style XC fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style INET fill:#455A64,color:#fff,stroke:#78909C
+    style SJC fill:#1565C0,color:#fff,stroke:#42A5F5
+    style IAD fill:#1565C0,color:#fff,stroke:#42A5F5
+    style BIGIPA fill:#00695C,color:#fff,stroke:#26A69A
+    style BIGIPB fill:#BF360C,color:#fff,stroke:#FF8F00
+    style NET fill:#37474F,color:#fff,stroke:#78909C
+    style DC fill:#263238,stroke:#78909C,color:#fff
+    style XC fill:#1A2744,stroke:#2196F3,color:#fff
 ```
 
 ### F5 Distributed Cloud (scrubbing center) sample
@@ -273,14 +273,16 @@ flowchart LR
     SJC -. "BGP tcp/179<br/>xXC_SJC2_INNER_V4x &#8594; xBIGIP_SJC2_INNER_V4x" .-> T3_INNER
     IAD -. "BGP tcp/179<br/>xXC_IAD2_INNER_V4x &#8594; xBIGIP_IAD2_INNER_V4x" .-> T4_INNER
 
-    style SJC fill:#4a90d9,color:#fff
-    style IAD fill:#4a90d9,color:#fff
-    style T1_INNER fill:#2e7d32,color:#fff
-    style T2_INNER fill:#2e7d32,color:#fff
-    style T3_INNER fill:#f57f17,color:#fff
-    style T4_INNER fill:#f57f17,color:#fff
-    style DC fill:#e3f2fd,stroke:#1565c0,color:#000
-    style XC fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style SJC fill:#1565C0,color:#fff,stroke:#42A5F5
+    style IAD fill:#1565C0,color:#fff,stroke:#42A5F5
+    style T1_INNER fill:#00695C,color:#fff,stroke:#26A69A
+    style T2_INNER fill:#00695C,color:#fff,stroke:#26A69A
+    style T3_INNER fill:#BF360C,color:#fff,stroke:#FF8F00
+    style T4_INNER fill:#BF360C,color:#fff,stroke:#FF8F00
+    style BIGIPA fill:#1A332D,stroke:#4DB6AC,color:#fff
+    style BIGIPB fill:#33261A,stroke:#FFB74D,color:#fff
+    style DC fill:#263238,stroke:#78909C,color:#fff
+    style XC fill:#1A2744,stroke:#2196F3,color:#fff
 ```
 
 ---
@@ -955,14 +957,17 @@ flowchart LR
     UNITA --> SERVERS
     UNITB --> SERVERS
 
-    style SJC fill:#4a90d9,color:#fff
-    style IAD fill:#4a90d9,color:#fff
-    style A_SJC fill:#2e7d32,color:#fff
-    style A_IAD fill:#2e7d32,color:#fff
-    style B_SJC fill:#f57f17,color:#fff
-    style B_IAD fill:#f57f17,color:#fff
-    style DC fill:#e3f2fd,stroke:#1565c0,color:#000
-    style F5XC fill:#e8f5e9,stroke:#2e7d32,color:#000
+    style SJC fill:#1565C0,color:#fff,stroke:#42A5F5
+    style IAD fill:#1565C0,color:#fff,stroke:#42A5F5
+    style A_SJC fill:#00695C,color:#fff,stroke:#26A69A
+    style A_IAD fill:#00695C,color:#fff,stroke:#26A69A
+    style B_SJC fill:#BF360C,color:#fff,stroke:#FF8F00
+    style B_IAD fill:#BF360C,color:#fff,stroke:#FF8F00
+    style SERVERS fill:#37474F,color:#fff,stroke:#78909C
+    style UNITA fill:#1A332D,stroke:#4DB6AC,color:#fff
+    style UNITB fill:#33261A,stroke:#FFB74D,color:#fff
+    style DC fill:#263238,stroke:#78909C,color:#fff
+    style F5XC fill:#1A2744,stroke:#2196F3,color:#fff
 ```
 
 - **Independent tunnel endpoints**: Each BIG-IP unit has its own

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,27 @@
+/* White canvas for Mermaid diagrams on both themes */
+.mermaid {
+  background: #fff;
+  border-radius: 4px;
+  padding: 1rem;
+}
+
+/*
+ * Force light-theme Mermaid rendering inside the dark (slate) scheme.
+ * CSS custom properties pierce shadow DOM, so overriding --md-default-*
+ * and --md-mermaid-* on .mermaid makes the shadow-rendered SVG use
+ * light colors even when the page is in dark mode.
+ */
+[data-md-color-scheme="slate"] .mermaid {
+  --md-default-bg-color: #ffffff;
+  --md-default-fg-color: hsla(0, 0%, 0%, 0.87);
+  --md-default-fg-color--light: hsla(0, 0%, 0%, 0.54);
+  --md-default-fg-color--lighter: hsla(0, 0%, 0%, 0.32);
+  --md-default-fg-color--lightest: hsla(0, 0%, 0%, 0.07);
+  --md-code-fg-color: hsla(0, 0%, 13%, 0.82);
+  --md-code-bg-color: hsla(0, 0%, 96%, 1);
+  --md-mermaid-label-bg-color: #ffffff;
+  --md-mermaid-label-fg-color: hsla(0, 0%, 13%, 0.82);
+  --md-mermaid-edge-color: hsla(0, 0%, 13%, 0.82);
+  --md-mermaid-node-bg-color: #526cfe1a;
+  --md-mermaid-node-fg-color: #526cfe;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,9 @@ theme:
     - search.highlight
     - search.suggest
 
+extra_css:
+  - stylesheets/extra.css
+
 plugins:
   - search
   - placeholder


### PR DESCRIPTION
## Summary
Enhanced documentation visual styling with updated Mermaid diagram colors and custom CSS stylesheet support.

## Changes
- Updated all diagram node colors with Material Design palette
- Added stroke colors for improved visual definition
- Implemented custom stylesheet infrastructure (docs/stylesheets/)
- Updated mkdocs.yml with extra_css configuration

## Benefits
- Improved visual contrast and accessibility
- Better consistency across all architecture diagrams
- Foundation for additional style customization

Closes #13